### PR TITLE
Install or upgrade WSL using a custom action

### DIFF
--- a/.github/actions/install-wsl/action.yaml
+++ b/.github/actions/install-wsl/action.yaml
@@ -1,0 +1,59 @@
+name: Install WSL
+author: Zygmunt Krynicki
+description: |
+  Install or upgrade WSL to the specified release.
+inputs:
+  wsl-msi-url:
+    description: URL of the MSI installer
+    required: false
+    default: https://github.com/microsoft/WSL/releases/download/2.2.4/wsl.2.2.4.0.x64.msi
+  wsl-msi-file:
+    description: Name of the WSL installer
+    required: false
+    default: wsl.2.2.4.0.x64.msi
+branding:
+  icon: download
+  color: orange
+runs:
+  using: composite
+  steps:
+    - name: Cache ${{ inputs.wsl-msi-file }} WSL installer
+      id: cache-wsl-installer
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.wsl-msi-file }}
+        key: ${{ inputs.wsl-msi-file }}
+    - name: Download WSL installer version ${{ inputs.wsl-msi-file }}
+      if: ${{ steps.cache-wsl-installer.outputs.cache-hit != 'true' }}
+      shell: pwsh
+      run: |
+        Set-StrictMode -version latest
+        $ProgressPreference = 'SilentlyContinue'
+        Write-Output "Downloading WSL installer release from GitHub..."
+        Invoke-WebRequest -Uri "${{ inputs.wsl-msi-url }}" -OutFile "${{ inputs.wsl-msi-file }}" -UseBasicParsing
+        if ( ! $? ) {
+          exit 1
+        }
+    - name: Install/Upgrade WSL
+      shell: pwsh
+      run: |
+        Set-StrictMode -version latest
+        Write-Output "Running WSL installer..."
+        Start-Process -Wait -NoNewWindow msiexec.exe -ArgumentList "/quiet /passive /package ${{ inputs.wsl-msi-file }}"
+        if ( ! $? ) {
+          exit 1
+        }
+        Write-Output "Switching to WSL 2."
+        Start-Process -NoNewWindow -Wait -FilePath "wsl.exe" -ArgumentList "--set-default-version 2"
+        if ( ! $? ) {
+          exit 1
+        }
+        Write-Output "Querying WSL version and status."
+        Start-Process -NoNewWindow -Wait -FilePath "wsl.exe" -ArgumentList "--version"
+        if ( ! $? ) {
+          exit 1
+        }
+        Start-Process -NoNewWindow -Wait -FilePath "wsl.exe" -ArgumentList "--status"
+        if ( ! $? ) {
+          exit 1
+        }

--- a/.github/workflows/generic.yaml
+++ b/.github/workflows/generic.yaml
@@ -46,46 +46,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache ${{ inputs.wsl-msi-file }} WSL installer
-        id: cache-wsl-installer
-        uses: actions/cache@v4
-        with:
-          path: ${{ inputs.wsl-msi-file }}
-          key: ${{ inputs.wsl-msi-file }}
-
-      - name: Download WSL installer version ${{ inputs.wsl-msi-file }}
-        if: ${{ steps.cache-wsl-installer.outputs.cache-hit != 'true' }}
-        run: |
-          Set-StrictMode -version latest
-          $ProgressPreference = 'SilentlyContinue'
-          Write-Output "Downloading WSL installer release from GitHub..."
-          Invoke-WebRequest -Uri "${{ inputs.wsl-msi-url }}" -OutFile "${{ inputs.wsl-msi-file }}" -UseBasicParsing
-          if ( ! $? ) {
-            exit 1
-          }
-
-      - name: Install/Upgrade WSL
-        run: |
-          Set-StrictMode -version latest
-          Write-Output "Running WSL installer..."
-          Start-Process -Wait -NoNewWindow msiexec.exe -ArgumentList "/quiet /passive /package ${{ inputs.wsl-msi-file }}"
-          if ( ! $? ) {
-            exit 1
-          }
-          Write-Output "Switching to WSL 2."
-          Start-Process -NoNewWindow -Wait -FilePath "wsl.exe" -ArgumentList "--set-default-version 2"
-          if ( ! $? ) {
-            exit 1
-          }
-          Write-Output "Querying WSL version and status."
-          Start-Process -NoNewWindow -Wait -FilePath "wsl.exe" -ArgumentList "--version"
-          if ( ! $? ) {
-            exit 1
-          }
-          Start-Process -NoNewWindow -Wait -FilePath "wsl.exe" -ArgumentList "--status"
-          if ( ! $? ) {
-            exit 1
-          }
+      - name: Install WSL
+        uses: ./.github/actions/install-wsl
 
       - name: Cache ${{ inputs.distro-name }} ${{ inputs.architecture }} WSL RootFS
         id: cache-rootfs


### PR DESCRIPTION
There's still some duplication in the fact that the URL and the basename of the URL of the WSL installer needs to be explicitly provided if you want to customize the version, but actual use is much easier now.