### PR TITLE
Remove wsl-enable-cloud-init-hack

### DIFF
--- a/.github/actions/setup-distro/action.yaml
+++ b/.github/actions/setup-distro/action.yaml
@@ -28,10 +28,6 @@ inputs:
     description: Explicitly enable systemd boot in the wsl-distro-name
     required: false
     default: "false"
-  wsl-enable-cloud-init-hack:
-    description: Enable cloud-init for WSL (hack)
-    required: false
-    default: "false"
   cloud-init-user-data:
     description: Text of the cloud-init user-data file
     required: false
@@ -155,53 +151,6 @@ runs:
           exit 1
         }
 
-    - name: Configure ${{ inputs.distro-name }} to support cloud-init (hacks)
-      shell: pwsh
-      if: ${{ fromJSON(inputs.wsl-enable-cloud-init-hack) }}
-      env:
-        WSL_DISTRO_NAME: ${{ inputs.wsl-distro-name }}
-      run: |
-        Set-StrictMode -version latest
-
-        Write-Output "Adding ubuntu-wsl-dev PPA to ${Env:WSL_DISTRO_NAME}..."
-        $wslArgs=@(
-          "--distribution ${Env:WSL_DISTRO_NAME}"
-          "--user root"
-          "--cd /"
-          "--exec add-apt-repository -y ppa:ubuntu-wsl-dev/ppa"
-        )
-        Start-Process -NoNewWindow -Wait -FilePath "wsl.exe" -ArgumentList $wslArgs
-        if ( ! $? ) {
-          Write-Error "Cannot add ubuntu-wsl-dev PPA to ${Env:WSL_DISTRO_NAME}."
-          exit 1
-        }
-
-        Write-Output "Installing wsl-setup and cloud-init in ${Env:WSL_DISTRO_NAME}..."
-        $wslArgs=@(
-          "--distribution ${Env:WSL_DISTRO_NAME}"
-          "--user root"
-          "--cd /"
-          "--exec env DEBIAN_FRONTEND=noninteractive apt install -y wsl-setup cloud-init"
-        )
-        Start-Process -NoNewWindow -Wait -FilePath "wsl.exe" -ArgumentList $wslArgs
-        if ( ! $? ) {
-          Write-Error "Cannot install wsl-setup and cloud-init in ${Env:WSL_DISTRO_NAME}."
-          exit 1
-        }
-
-        Write-Output "Installing enabling cloud-init.service and cloud-init-local.service in ${Env:WSL_DISTRO_NAME}..."
-        $wslArgs=@(
-          "--distribution ${Env:WSL_DISTRO_NAME}"
-          "--user root"
-          "--cd /"
-          "--exec systemctl --root=/ enable cloud-init.service cloud-init-local.service"
-        )
-        Start-Process -NoNewWindow -Wait -FilePath "wsl.exe" -ArgumentList $wslArgs
-        if ( ! $? ) {
-          Write-Error "Cannot enable cloud-init.service and cloud-init-local.service in ${Env:WSL_DISTRO_NAME}."
-          exit 1
-        }
-
     - name: Setup ${{ inputs.distro-name }} WSL instance with cloud-init
       shell: pwsh
       env:
@@ -224,7 +173,7 @@ runs:
           exit 1
         }
 
-        if ( "$${{ inputs.wsl-enable-cloud-init-hack }}" -eq "true" || "$${{ inputs.wsl-enable-systemd }}" -eq "true" ) {
+        if ("$${{ inputs.wsl-enable-systemd }}" -eq "true" ) {
           Write-Output "Terminating ${Env:WSL_DISTRO_NAME} for earlier changes to take effect..."
           Start-Process -NoNewWindow -Wait -FilePath "wsl.exe" -ArgumentList "--terminate ${Env:WSL_DISTRO_NAME}"
           if ( ! $? ) {

--- a/.github/actions/setup-distro/action.yaml
+++ b/.github/actions/setup-distro/action.yaml
@@ -5,7 +5,7 @@ name: Setup WSL wsl-distro-name
 author: Zygmunt Krynicki
 description: |
   Download a WSL wsl-distro-name rootfs, import it into the system, optionally
-  enable systemd, and initialize with cloud-init.
+  enable systemd, and initialize by hand.
 inputs:
   wsl-distro-name:
     description: Name of wsl-distro-name instance
@@ -28,26 +28,6 @@ inputs:
     description: Explicitly enable systemd boot in the wsl-distro-name
     required: false
     default: "false"
-  cloud-init-user-data:
-    description: Text of the cloud-init user-data file
-    required: false
-    default: |
-      #cloud-config
-
-      locale: en_US
-
-      users:
-        - name: user
-          gecos: user
-          primary_group: user
-          lock_passwd: false
-          sudo: ALL=(ALL) NOPASSWD:ALL
-          groups:
-            - users
-            - admin
-            - lxd # For using LXD without sudo
-            - docker # For using Docker without sudo
-          shell: /bin/bash
 outputs:
   wsl-workspace-path:
     description: Path of the GitHub workspace inside WSL
@@ -151,27 +131,12 @@ runs:
           exit 1
         }
 
-    - name: Setup ${{ inputs.distro-name }} WSL instance with cloud-init
+    - name: Setup ${{ inputs.distro-name }} WSL instance
       shell: pwsh
       env:
         WSL_DISTRO_NAME: ${{ inputs.wsl-distro-name }}
-        CLOUD_INIT_USER_DATA: ${{ inputs.cloud-init-user-data }}
       run: |
         Set-StrictMode -version latest
-
-        Write-Output "Preparing cloud-init configuration for WSL."
-        if ( -not ( Test-Path -PathType Container -LiteralPath "${Env:USERPROFILE}\.cloud-init" ) ) {
-          New-Item -ItemType Directory -Path ${Env:USERPROFILE} -Name ".cloud-init"
-          if ( ! $? ) {
-            Write-Error "Cannot create .cloud-init directory."
-            exit 1
-          }
-        }
-        New-Item -Force -ItemType File -Path "${Env:USERPROFILE}\.cloud-init" -Name "${Env:WSL_DISTRO_NAME}.user-data" -Value ${Env:CLOUD_INIT_USER_DATA}
-        if ( ! $? ) {
-          Write-Error "Cannot create cloud-init user-data file for ${Env:WSL_DISTRO_NAME}."
-          exit 1
-        }
 
         if ("$${{ inputs.wsl-enable-systemd }}" -eq "true" ) {
           Write-Output "Terminating ${Env:WSL_DISTRO_NAME} for earlier changes to take effect..."
@@ -182,29 +147,55 @@ runs:
           }
         }
 
-        Write-Output "Starting ${Env:WSL_DISTRO_NAME} and waiting for cloud-init to finish..."
+        Write-Output "Adding system group for docker."
         $wslArgs=@(
           "--distribution ${Env:WSL_DISTRO_NAME}"
           "--user root"
           "--cd /"
-          "--exec cloud-init status --wait"
+          "groupadd --system docker"
         )
         Start-Process -NoNewWindow -Wait -FilePath "wsl.exe" -ArgumentList $wslArgs
         if ( ! $? ) {
-          Write-Error "Cannot start ${Env:WSL_DISTRO_NAME} and finish cloud-init process."
+          Write-Error "Cannot add docker system group."
           exit 1
         }
 
-        Write-Output "Validating cloud-init schema."
+        Write-Output "Adding system group for LXD."
         $wslArgs=@(
           "--distribution ${Env:WSL_DISTRO_NAME}"
           "--user root"
           "--cd /"
-          "--exec cloud-init schema --system"
+          "groupadd --system lxd"
         )
         Start-Process -NoNewWindow -Wait -FilePath "wsl.exe" -ArgumentList $wslArgs
         if ( ! $? ) {
-          Write-Error "Cannot validate cloud-init schema of ${Env:WSL_DISTRO_NAME}."
+          Write-Error "Cannot add lxd system group."
+          exit 1
+        }
+
+        Write-Output "Adding test user 'user'."
+        $wslArgs=@(
+          "--distribution ${Env:WSL_DISTRO_NAME}"
+          "--user root"
+          "--cd /"
+          "useradd --create-home --skel /etc/skel --groups users,admin,lxd,docker --shell=/bin/bash user"
+        )
+        Start-Process -NoNewWindow -Wait -FilePath "wsl.exe" -ArgumentList $wslArgs
+        if ( ! $? ) {
+          Write-Error "Cannot add test user 'user'."
+          exit 1
+        }
+
+        Write-Output "Allow test user 'user' to use sudo."
+        $wslArgs=@(
+          "--distribution ${Env:WSL_DISTRO_NAME}"
+          "--user root"
+          "--cd /"
+          "echo 'user ALL= NOPASSWD: ALL' >/etc/sudoers.d/user.conf"
+        )
+        Start-Process -NoNewWindow -Wait -FilePath "wsl.exe" -ArgumentList $wslArgs
+        if ( ! $? ) {
+          Write-Error "Cannot allow test user 'user' to use sudo."
           exit 1
         }
 

--- a/.github/workflows/generic.yaml
+++ b/.github/workflows/generic.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Install WSL
         uses: ./.github/actions/install-wsl
 
-      - name: Import ${{ inputs.wsl-distro-name }} into WSL and run cloud-init
+      - name: Import ${{ inputs.wsl-distro-name }} into WSL and initialize it
         id: setup-distro
         uses: ./.github/actions/setup-distro
         with:
@@ -135,7 +135,7 @@ jobs:
       - name: Install WSL
         uses: ./.github/actions/install-wsl
 
-      - name: Import ${{ inputs.wsl-distro-name }} into WSL and run cloud-init
+      - name: Import ${{ inputs.wsl-distro-name }} into WSL and initialize it
         id: setup-distro
         uses: ./.github/actions/setup-distro
         with:
@@ -262,7 +262,7 @@ jobs:
       - name: Install WSL
         uses: ./.github/actions/install-wsl
 
-      - name: Import ${{ inputs.wsl-distro-name }} into WSL and run cloud-init
+      - name: Import ${{ inputs.wsl-distro-name }} into WSL and initialize it
         id: setup-distro
         uses: ./.github/actions/setup-distro
         with:

--- a/.github/workflows/generic.yaml
+++ b/.github/workflows/generic.yaml
@@ -23,10 +23,6 @@ on:
         required: false
         type: boolean
         default: false
-      wsl-enable-cloud-init-hack:
-        required: false
-        type: boolean
-        default: false
       wsl-msi-url:
         required: false
         type: string
@@ -65,7 +61,6 @@ jobs:
           wsl-rootfs-url: ${{ inputs.wsl-rootfs-url }}
           wsl-rootfs-file: ${{ inputs.wsl-rootfs-file }}
           wsl-enable-systemd: ${{ inputs.wsl-enable-systemd }}
-          wsl-enable-cloud-init-hack: ${{ inputs.wsl-enable-cloud-init-hack }}
 
       - name: Install snapd snap from a channel
         uses: ./.github/actions/install-snap
@@ -148,7 +143,6 @@ jobs:
           wsl-rootfs-url: ${{ inputs.wsl-rootfs-url }}
           wsl-rootfs-file: ${{ inputs.wsl-rootfs-file }}
           wsl-enable-systemd: ${{ inputs.wsl-enable-systemd }}
-          wsl-enable-cloud-init-hack: ${{ inputs.wsl-enable-cloud-init-hack }}
 
       - name: Install snapd snap from a channel
         uses: ./.github/actions/install-snap
@@ -276,7 +270,6 @@ jobs:
           wsl-rootfs-url: ${{ inputs.wsl-rootfs-url }}
           wsl-rootfs-file: ${{ inputs.wsl-rootfs-file }}
           wsl-enable-systemd: ${{ inputs.wsl-enable-systemd }}
-          wsl-enable-cloud-init-hack: ${{ inputs.wsl-enable-cloud-init-hack }}
 
       - name: Install snapd snap from a channel
         uses: ./.github/actions/install-snap

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -33,12 +33,10 @@ jobs:
       matrix:
         lts: [false]
         wsl-enable-systemd: [false]
-        wsl-enable-cloud-init-hack: [false]
         include:
           - codename: jammy
             version-id: "22.04"
             wsl-enable-systemd: true
-            wsl-enable-cloud-init-hack: true
           - codename: noble
             version-id: "24.04"
     uses: ./.github/workflows/generic.yaml
@@ -48,6 +46,5 @@ jobs:
       wsl-rootfs-file: ubuntu-${{ matrix.codename }}-wsl-amd64-wsl.rootfs.tar.gz
       wsl-distro-name: Test-Ubuntu-${{ matrix.version-id }}
       wsl-enable-systemd: ${{ matrix.wsl-enable-systemd }}
-      wsl-enable-cloud-init-hack: ${{ matrix.wsl-enable-cloud-init-hack }}
       snapd-snap-revision: ${{ github.event.inputs.snapd-snap-revision != 0 && fromJSON(github.event.inputs.snapd-snap-revision) || 0 }}
       snapd-snap-channel: ${{ github.event.inputs.snapd-snap-channel != '' && github.event.inputs.snapd-snap-channel || 'latest/stable' }}


### PR DESCRIPTION
The hack no longer works so it's better to disable it and transition to something that does not rely on cloud-init for testing. The existing switch to enable systemd support when it is not enabled by default should remain, as it is correct and keeps working.