### PR TITLE
Test hello-world.evil with a custom kernel

### DIFF
--- a/.github/workflows/generic.yaml
+++ b/.github/workflows/generic.yaml
@@ -376,3 +376,137 @@ jobs:
 
           Start-Process -NoNewWindow -Wait -FilePath "wsl.exe" -ArgumentList "--terminate $DistroName"
           Start-Process -NoNewWindow -Wait -FilePath "wsl.exe" -ArgumentList "--unregister $DistroName"
+
+  hello-world_evil:
+    name: "Smoke test with \"hello-world\" snap"
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache custom kernel image
+        id: cache-kernel-image
+        uses: actions/cache@v4
+        with:
+          path: vmlinux-wsl2-snapd-x86_64
+          key: vmlinux-wsl2-snapd-x86_64
+
+      - name: Download a custom kernel
+        if: ${{ steps.cache-kernel-image.outputs.cache-hit != 'true' }}
+        run: |
+          Set-StrictMode -version latest
+          $ProgressPreference = 'SilentlyContinue'
+          Write-Output "Downloading a custom linux kernel..."
+          Invoke-WebRequest -Uri "https://github.com/diddlesnaps/WSL2-Linux-Kernel/releases/download/linux-msft-snapd-5.15.146.1/vmlinux-wsl2-snapd-x86_64" -OutFile "vmlinux-wsl2-snapd-x86_64" -UseBasicParsing
+          if ( ! $? ) {
+            exit 1
+          }
+
+      - name: Install WSL
+        uses: ./.github/actions/install-wsl
+        with:
+          wslconfig-vm-idle-timeout: -1
+          wslconfig-kernel: ${{ github.workspace }}\vmlinux-wsl2-snapd-x86_64
+          wslconfig-kernel-command-line: security=apparmor
+
+      - name: Import ${{ inputs.wsl-distro-name }} into WSL and initialize it
+        id: setup-distro
+        uses: ./.github/actions/setup-distro
+        with:
+          wsl-distro-name: ${{ inputs.wsl-distro-name }}
+          wsl-rootfs-url: ${{ inputs.wsl-rootfs-url }}
+          wsl-rootfs-file: ${{ inputs.wsl-rootfs-file }}
+          wsl-enable-systemd: ${{ inputs.wsl-enable-systemd }}
+
+      - name: Mount securityfs, start apparmor and restart snapd
+        env:
+          WSL_DISTRO_NAME: ${{ inputs.wsl-distro-name }}
+        run: |
+          Set-StrictMode -version latest
+          wsl --distribution ${Env:WSL_DISTRO_NAME} uname -a
+          wsl --distribution ${Env:WSL_DISTRO_NAME} mount -t securityfs securityfs /sys/kernel/security
+          wsl --distribution ${Env:WSL_DISTRO_NAME} systemctl start apparmor.service
+          wsl --distribution ${Env:WSL_DISTRO_NAME} systemctl start snapd.apparmor.service
+          wsl --distribution ${Env:WSL_DISTRO_NAME} systemctl restart snapd.service
+
+      - name: Inspect the state of AppArmor
+        env:
+          WSL_DISTRO_NAME: ${{ inputs.wsl-distro-name }}
+        run: |
+          Set-StrictMode -version latest
+          wsl --distribution ${Env:WSL_DISTRO_NAME} cat /proc/self/mountinfo
+          wsl --distribution ${Env:WSL_DISTRO_NAME} cat /proc/cmdline
+          wsl --distribution ${Env:WSL_DISTRO_NAME} systemctl status apparmor.service
+          wsl --distribution ${Env:WSL_DISTRO_NAME} aa-enabled
+          wsl --distribution ${Env:WSL_DISTRO_NAME} aa-status
+          wsl --distribution ${Env:WSL_DISTRO_NAME} ls -l /sys/kernel/security/apparmor/
+          wsl --distribution ${Env:WSL_DISTRO_NAME} systemctl status snapd.apparmor.service
+          wsl --distribution ${Env:WSL_DISTRO_NAME} snap debug sandbox-features
+
+      - name: Install snapd snap from a channel
+        uses: ./.github/actions/install-snap
+        if: ${{ inputs.snapd-snap-revision == 0 }}
+        with:
+          wsl-distro-name: ${{ inputs.wsl-distro-name }}
+          snap-name: snapd
+          snap-channel: ${{ inputs.snapd-snap-channel }}
+
+      - name: Install specific snapd snap revision
+        uses: ./.github/actions/install-snap
+        if: ${{ inputs.snapd-snap-revision != 0 }}
+        with:
+          wsl-distro-name: ${{ inputs.wsl-distro-name }}
+          snap-name: snapd
+          snap-revision: ${{ inputs.snapd-snap-revision }}
+
+      - name: Hold all snap refreshes
+        env:
+          WSL_DISTRO_NAME: ${{ inputs.wsl-distro-name }}
+        run: |
+          Set-StrictMode -version latest
+          wsl --distribution ${Env:WSL_DISTRO_NAME} snap refresh --hold
+
+      - name: Install core snap
+        uses: ./.github/actions/install-snap
+        with:
+          wsl-distro-name: ${{ inputs.wsl-distro-name }}
+          snap-name: core
+
+      - name: Install hello-world snap
+        uses: ./.github/actions/install-snap
+        with:
+          wsl-distro-name: ${{ inputs.wsl-distro-name }}
+          snap-name: hello-world
+
+      - name: Run hello-world.evil snap application
+        env:
+          WSL_DISTRO_NAME: ${{ inputs.wsl-distro-name }}
+        run: |
+          Set-StrictMode -version latest
+          Write-Output "Running hello-world.evil application."
+          $output = wsl --distribution ${Env:WSL_DISTRO_NAME} --exec sh -c "snap run hello-world.evil 2>&1 || true" | Out-String -Stream
+          Write-Output $output
+
+          # NOTE: $output is an array and -notlike would match all the other items.
+          if (!($output -like "*/myevil.txt: Permission denied")) {
+            Write-Error "Expected failure but didn't see any."
+            exit 1
+          } else {
+            Write-Output "Basic snap confinement is in place"
+          }
+
+      - name: Inspect snap changes
+        env:
+          WSL_DISTRO_NAME: ${{ inputs.wsl-distro-name }}
+        run: |
+          Set-StrictMode -version latest
+          wsl --distribution ${Env:WSL_DISTRO_NAME} snap changes
+
+      - name: Terminate ${{ inputs.distro-name }} WSL instance
+        if: always()
+        env:
+          WSL_DISTRO_NAME: ${{ inputs.wsl-distro-name }}
+        run: |
+          Set-StrictMode -version latest
+          Write-Output "Terminating ${Env:WSL_DISTRO_NAME} WSL instance..."
+          wsl --terminate ${Env:WSL_DISTRO_NAME}
+          wsl --unregister ${Env:WSL_DISTRO_NAME}


### PR DESCRIPTION
There's a bit of hackery involved in this test but it allows
us to use snapd on WSL with a custom, snap-enabled kernel, with
hand-mounted securityfs.