### PR TITLE
Move .wslconfig initialization to install-wsl

### DIFF
--- a/.github/actions/install-wsl/action.yaml
+++ b/.github/actions/install-wsl/action.yaml
@@ -14,6 +14,21 @@ inputs:
     description: Name of the WSL installer
     required: false
     default: wsl.2.2.4.0.x64.msi
+  # Remaining inputs describe wslconfig file:
+  # https://learn.microsoft.com/en-us/windows/wsl/wsl-config
+  # Only a small subset is implemented, as needed.
+  wslconfig-kernel:
+    description: Path to the Linux kernel file stored on the Windows file system
+    required: false
+    default: ""
+  wslconfig-kernel-command-line:
+    description: Path to the Linux kernel file stored on the Windows file system
+    required: false
+    default: ""
+  wslconfig-vm-idle-timeout:
+    description: Number of millisceconds to wait before shutting down an idle instance
+    required: false
+    default: 60000
 branding:
   icon: download
   color: orange
@@ -58,5 +73,26 @@ runs:
         }
         Start-Process -NoNewWindow -Wait -FilePath "wsl.exe" -ArgumentList "--status"
         if ( ! $? ) {
+          exit 1
+        }
+
+    - name: Create a .wslconfig file
+      shell: pwsh
+      run: |
+        Set-StrictMode -version latest
+
+        Write-Output "Preparing WSL configuration file."
+        # This is expanded using single quote at string, since the expansion is
+        # done by GitHub logic, not powershell.
+        $WslConfig = @'
+        [wsl2]
+        ${{ inputs.wslconfig-vm-idle-timeout != '' && format('vmIdleTimeout = {0}', inputs.wslconfig-vm-idle-timeout) || '# vmIdleTimeout is not set' }}
+        ${{ inputs.wslconfig-kernel != '' && format('kernel = {0}', inputs.wslconfig-kernel) || '# kernel is not set' }}
+        ${{ inputs.wslconfig-kernel-command-line != '' && format('kernelCommandLine = {0}', inputs.wslconfig-kernel-command-line) || '# kernelCommandLine is not set' }}
+        '@
+
+        New-Item -Force -ItemType File -Path "${Env:USERPROFILE}" -Name ".wslconfig" -Value "$WslConfig"
+        if ( ! $? ) {
+          Write-Error "Cannot create WSL configuration file."
           exit 1
         }

--- a/.github/actions/setup-distro/action.yaml
+++ b/.github/actions/setup-distro/action.yaml
@@ -77,26 +77,6 @@ runs:
       run: |
         Set-StrictMode -version latest
 
-        Write-Output "Preparing WSL configuration file."
-        $WslConfig = @'
-        [wsl2]
-        vmIdleTimeout = -1
-        '@
-
-        New-Item -Force -ItemType File -Path "${Env:USERPROFILE}" -Name ".wslconfig" -Value "$WslConfig"
-        if ( ! $? ) {
-          Write-Error "Cannot create WSL configuration file."
-          exit 1
-        }
-
-        if ( -not ( Test-Path -PathType Container -LiteralPath ${Env:WSL_VMS_DIR} ) ) {
-          New-Item -ItemType Directory -Name ${Env:WSL_VMS_DIR}
-          if ( ! $? ) {
-            Write-Error "Cannot create ${Env:WSL_VMS_DIR} directory."
-            exit 1
-          }
-        }
-
         Write-Output "Importing ${Env:WSL_ROOTFS_FILE} RootFS into WSL..."
         $wslArgs=@(
           "--import ${Env:WSL_DISTRO_NAME}"

--- a/.github/actions/setup-distro/action.yaml
+++ b/.github/actions/setup-distro/action.yaml
@@ -77,6 +77,10 @@ runs:
       run: |
         Set-StrictMode -version latest
 
+        if ( -not ( Test-Path -PathType Container -LiteralPath ${Env:WSL_VMS_DIR} ) ) {
+          New-Item -ItemType Directory -Name ${Env:WSL_VMS_DIR}
+        }
+
         Write-Output "Importing ${Env:WSL_ROOTFSES_DIR}\${Env:WSL_ROOTFS_FILE} RootFS into WSL..."
         $wslArgs=@(
           "--import ${Env:WSL_DISTRO_NAME}"

--- a/.github/actions/setup-distro/action.yaml
+++ b/.github/actions/setup-distro/action.yaml
@@ -77,7 +77,7 @@ runs:
       run: |
         Set-StrictMode -version latest
 
-        Write-Output "Importing ${Env:WSL_ROOTFS_FILE} RootFS into WSL..."
+        Write-Output "Importing ${Env:WSL_ROOTFSES_DIR}\${Env:WSL_ROOTFS_FILE} RootFS into WSL..."
         $wslArgs=@(
           "--import ${Env:WSL_DISTRO_NAME}"
           ".\${Env:WSL_VMS_DIR}\${Env:WSL_DISTRO_NAME}"

--- a/.github/workflows/generic.yaml
+++ b/.github/workflows/generic.yaml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Install WSL
         uses: ./.github/actions/install-wsl
+        with:
+          wslconfig-vm-idle-timeout: -1
 
       - name: Import ${{ inputs.wsl-distro-name }} into WSL and initialize it
         id: setup-distro


### PR DESCRIPTION
Since the settings applied there are global and shared across all distribution instances, they belong in the same place as installation of wsl itself.

This unlocks the ability to use custom kernels.