### PR TITLE
Stop using Start-Process in setup-distro action

### DIFF
--- a/.github/actions/setup-distro/action.yaml
+++ b/.github/actions/setup-distro/action.yaml
@@ -82,13 +82,11 @@ runs:
         }
 
         Write-Output "Importing ${Env:WSL_ROOTFSES_DIR}\${Env:WSL_ROOTFS_FILE} RootFS into WSL..."
-        $wslArgs=@(
-          "--import ${Env:WSL_DISTRO_NAME}"
-          ".\${Env:WSL_VMS_DIR}\${Env:WSL_DISTRO_NAME}"
-          ".\${Env:WSL_ROOTFSES_DIR}\${Env:WSL_ROOTFS_FILE}"
-          "--version 2"
-        )
-        Start-Process -NoNewWindow -Wait -FilePath "wsl.exe" -ArgumentList $wslArgs
+        wsl `
+          --import "${Env:WSL_DISTRO_NAME}" `
+          ".\${Env:WSL_VMS_DIR}\${Env:WSL_DISTRO_NAME}" `
+          ".\${Env:WSL_ROOTFSES_DIR}\${Env:WSL_ROOTFS_FILE}" `
+          --version 2
         if ( ! $? ) {
           Write-Error "Cannot import ${Env:WSL_DISTRO_NAME} into WSL."
           exit 1
@@ -102,18 +100,29 @@ runs:
       run: |
         Set-StrictMode -version latest
 
+        # As ironic as this is, WSL-specific init process cannot cope with \r\n
+        # line endings in the /etc/wsl.conf initialization file. Explicitly
+        # replace them with UNIX line endings and carefully write as a byte
+        # stream to avoid any accidental conversions.
+        $wslConf = @'
+        [boot]
+        systemd=true
+
+        '@.Replace("`r`n", "`n")
+
         Write-Output "Enabling systemd boot in ${Env:WSL_DISTRO_NAME}..."
-        $wslArgs=@(
-          "--distribution ${Env:WSL_DISTRO_NAME}"
-          "--user root"
-          "--cd /"
-          "printf '[boot]\nsystemd=true\n' >> /etc/wsl.conf"
-        )
-        Start-Process -NoNewWindow -Wait -FilePath "wsl.exe" -ArgumentList $wslArgs
+        Add-Content `
+          -LiteralPath "\\wsl.localhost\${Env:WSL_DISTRO_NAME}\etc\wsl.conf" `
+          -Value $([System.Text.Encoding]::UTF8.GetBytes($wslConf)) `
+          -NoNewLine `
+          -AsByteStream
         if ( ! $? ) {
           Write-Error "Cannot enable systemd boot in ${Env:WSL_DISTRO_NAME}."
           exit 1
         }
+
+        type "\\wsl.localhost\${Env:WSL_DISTRO_NAME}\etc\wsl.conf"
+        wsl --distribution "${Env:WSL_DISTRO_NAME}" --exec od -t c /etc/wsl.conf
 
         Write-Output "Terminating ${Env:WSL_DISTRO_NAME} for earlier changes to take effect..."
         wsl --terminate "${Env:WSL_DISTRO_NAME}"
@@ -137,52 +146,42 @@ runs:
         Set-StrictMode -version latest
 
         Write-Output "Adding system group for docker."
-        $wslArgs=@(
-          "--distribution ${Env:WSL_DISTRO_NAME}"
-          "--user root"
-          "--cd /"
-          "groupadd --system docker"
-        )
-        Start-Process -NoNewWindow -Wait -FilePath "wsl.exe" -ArgumentList $wslArgs
+        wsl `
+          --distribution "${Env:WSL_DISTRO_NAME}" `
+          --user root `
+          --cd / `
+          groupadd --system docker
         if ( ! $? ) {
           Write-Error "Cannot add docker system group."
           exit 1
         }
 
         Write-Output "Adding system group for LXD."
-        $wslArgs=@(
-          "--distribution ${Env:WSL_DISTRO_NAME}"
-          "--user root"
-          "--cd /"
-          "groupadd --system lxd"
-        )
-        Start-Process -NoNewWindow -Wait -FilePath "wsl.exe" -ArgumentList $wslArgs
+        wsl `
+          --distribution "${Env:WSL_DISTRO_NAME}" `
+          --user root `
+          --cd / `
+          groupadd --system lxd
         if ( ! $? ) {
           Write-Error "Cannot add lxd system group."
           exit 1
         }
 
         Write-Output "Adding test user 'user'."
-        $wslArgs=@(
-          "--distribution ${Env:WSL_DISTRO_NAME}"
-          "--user root"
-          "--cd /"
-          "useradd --create-home --skel /etc/skel --groups users,admin,lxd,docker --shell=/bin/bash user"
-        )
-        Start-Process -NoNewWindow -Wait -FilePath "wsl.exe" -ArgumentList $wslArgs
+        wsl `
+          --distribution "${Env:WSL_DISTRO_NAME}" `
+          --user root `
+          --cd / `
+          useradd --create-home --skel /etc/skel --groups users,admin,lxd,docker --shell=/bin/bash user
         if ( ! $? ) {
           Write-Error "Cannot add test user 'user'."
           exit 1
         }
 
         Write-Output "Allow test user 'user' to use sudo."
-        $wslArgs=@(
-          "--distribution ${Env:WSL_DISTRO_NAME}"
-          "--user root"
-          "--cd /"
-          "echo 'user ALL= NOPASSWD: ALL' >/etc/sudoers.d/user.conf"
-        )
-        Start-Process -NoNewWindow -Wait -FilePath "wsl.exe" -ArgumentList $wslArgs
+        Add-Content `
+          -LiteralPath \\wsl.localhost\${Env:WSL_DISTRO_NAME}\etc\sudoers.d\user.conf `
+          -Value "user ALL= NOPASSWD: ALL"
         if ( ! $? ) {
           Write-Error "Cannot allow test user 'user' to use sudo."
           exit 1
@@ -196,17 +195,29 @@ runs:
       run: |
         Set-StrictMode -version latest
 
+        Write-Output "Workspace is at ${Env:GITHUB_WORKSPACE} (on Windows)"
+        $workspacePath = wsl --exec wslpath -u "${Env:GITHUB_WORKSPACE}".Replace('\', '\\')
+        Write-Output "Workspace is at $workspacePath (on Linux)"
+
         Write-Output "Creating a symlink for accessing GitHub workspace from WSL."
-        $wslArgs=@(
-          "--distribution ${Env:WSL_DISTRO_NAME}"
-          "--user root"
-          "--cd /"
-          "set -xeu && ln -s `"`$(wslpath -u '${{ github.workspace }}')`" /srv/github-workspace"
-        )
-        Start-Process -NoNewWindow -Wait -FilePath "wsl.exe" -ArgumentList $wslArgs
+        wsl `
+          --distribution "${Env:WSL_DISTRO_NAME}" `
+          --user root `
+          --cd / `
+          ln -s "$workspacePath" /srv/github-workspace
         if ( ! $? ) {
           Write-Error "Cannot create symlink for accessing GitHub workspace from WSL."
           exit 1
         }
+        wsl `
+          --distribution "${Env:WSL_DISTRO_NAME}" `
+          --user root `
+          --cd / `
+          ls -ld /srv/github-workspace
+        wsl `
+          --distribution "${Env:WSL_DISTRO_NAME}" `
+          --user root `
+          --cd / `
+          ls -ld "$workspacePath"
 
         Add-Content -LiteralPath ${Env:GITHUB_OUTPUT} -Value "wsl-workspace-path=/srv/github-workspace"


### PR DESCRIPTION
The failure of the resulting process is not resulting in the failure of the powershell command. There are more instances of this in other actions.

Refactor how /etc/wsl.conf, /etc/sudoers.d/user.conf and /srv/github-worskpace are created to simplify quoting and append interacting with powershell.